### PR TITLE
add a basic code climate config and corresponding badge to the README

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,13 @@
+engines:
+  duplication:
+    enabled: false
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+
+ratings:
+  paths:
+  - "**.py"
+
+exclude_paths:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # cg-stats
+[![Code Climate](https://codeclimate.com/github/18F/cg-stats-scripts/badges/gpa.svg)](https://codeclimate.com/github/18F/cg-stats-scripts)
 
 cg-stats is a script that will collect and print stats about a specified cloud foundry environment.
 


### PR DESCRIPTION
As part of the Fedramp effort, we are required to ensure static code analysis is run on all 18F developed code that is part of the cloud.gov platform:  https://github.com/18F/cg-product/issues/260

In support of this effort, this PR adds a basic code climate configuration and badge to the README.

**Also whomever is reviewing this PR please provide me with access to this repo, so I can configure the webhook required for automatically running code climate on each PR**
